### PR TITLE
Updated PaperTrader updatePosition method

### DIFF
--- a/plugins/paperTrader/paperTrader.js
+++ b/plugins/paperTrader/paperTrader.js
@@ -90,12 +90,12 @@ PaperTrader.prototype.updatePosition = function(what) {
     this.trades++;
   }
 
-  // virtually trade all {currency} to {asset}
+  // virtually trade all {asset} to {currency}
   // at the current price (minus fees)
   else if(what === 'short') {
     cost = (1 - this.fee) * (this.portfolio.asset * this.price);
+    amount = this.portfolio.asset;
     this.portfolio.currency += this.extractFee(this.portfolio.asset * this.price);
-    amount = this.portfolio.currency / this.price;
     this.portfolio.asset = 0;
 
     this.exposed = false;
@@ -186,7 +186,7 @@ PaperTrader.prototype.processAdvice = function(advice) {
     origin: advice.origin,
     infomsg: advice.infomsg, 
     setTakerLimit: advice.setTakerLimit,
-    portfolio: this.portfolio,
+    portfolio: _.clone(this.portfolio),
     balance: this.getBalance(),
     date: advice.date,
     effectivePrice,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When the <strike>position</strike> signal is short, the `amount = this.portfolio.currency / this.price` after the portfolio currency has been updated (fee extracted). But the actual amount that moved was the whole asset. 
At `tradeCompleted` event the portfolio property gets change with each trade because it is not cloned.

* **What is the new behavior (if this is a feature change)?**
The amount of a 'short' action will be correctly reported as the total asset amount of the portfolio.
Also, at `tradeCompleted` event send a clone of the portfolio so that it is reported correctly.


* **Other information**: